### PR TITLE
add support for loongarch

### DIFF
--- a/Source/WTF/wtf/dtoa/utils.h
+++ b/Source/WTF/wtf/dtoa/utils.h
@@ -82,6 +82,7 @@ int main(int argc, char** argv) {
 #if defined(_M_X64) || defined(__x86_64__) || \
     defined(__ARMEL__) || defined(__avr32__) || defined(_M_ARM) || defined(_M_ARM64) || \
     defined(__hppa__) || defined(__ia64__) || \
+    defined(__loongarch__) ||\
     defined(__mips__) || \
     defined(__powerpc__) || defined(__ppc__) || defined(__ppc64__) || \
     defined(_POWER) || defined(_ARCH_PPC) || defined(_ARCH_PPC64) || \


### PR DESCRIPTION
With this patch, purc can build and run on the LoongArch machine.
```
$ uname -m
loongarch64
$ file build/Source/Tools/purc/purc 
build/Source/Tools/purc/purc: ELF 64-bit LSB pie executable, LoongArch, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-loongarch-lp64d.so.1, BuildID[sha1]=dfb4b66ad76d680e33a2107244035cff2668a163, for GNU/Linux 5.15.0, with debug_info, not stripped
$ build/Source/Tools/purc/purc Source/Samples/hvml/hello.hvml 
Hello, world!
```
