### PR TITLE
Add PurC optional dependency packages and package group hvml and hvml-git information

### DIFF
--- a/Source/Tools/aur/purc-git/PKGBUILD
+++ b/Source/Tools/aur/purc-git/PKGBUILD
@@ -1,18 +1,23 @@
 # Maintainer: taotieren <admin@taotieren.com>
 
 pkgname=purc-git
-pkgver=0.8.1.r20.ga1702fd8
+pkgver=0.8.1.r53.g0ff03e64
 pkgrel=1
 pkgdesc="The prime HVML interpreter for C Language."
 arch=('any')
 url="https://github.com/HVML/PurC"
 license=('LGPL-3.0')
+groups=('hvml-git')
 provides=(${pkgname%-git} 'PurC')
 conflicts=(${pkgname%-git})
 #replaces=(${pkgname})
 depends=('glib2' 'bison' 'flex')
 makedepends=('git' 'cmake' 'ninja' 'ccache' 'gcc' 'python' 'libxml2' 'ruby' 'curl' 'openssl' 'sqlite' 'pkgconf' 'zlib' 'icu')
-optdepends=('domruler' 'purc-fetcher' 'xguipro')
+optdepends=('domruler: DOM Ruler is a library to maintain a DOM tree, lay out and stylize the DOM elements by using CSS.'
+            'purc-fetcher: The remote data fetcher for PurC.'
+            'purc-midnight-commander: A generic HVML renderer in text mode for development and debugging.'
+            'webkit2gtk-hvml: Web content engine for GTK (HVML)'
+            'xguipro: xGUI (the X Graphics User Interface) Pro is a modern, cross-platform, and advanced HVML renderer which is based on tailored WebKit.')
 backup=()
 options=('!strip')
 #install=${pkgname}.install

--- a/Source/Tools/aur/purc/PKGBUILD
+++ b/Source/Tools/aur/purc/PKGBUILD
@@ -2,17 +2,22 @@
 
 pkgname=purc
 pkgver=0.8.1
-pkgrel=4
+pkgrel=5
 pkgdesc="The prime HVML interpreter for C Language."
 arch=('any')
 url="https://github.com/HVML/PurC"
 license=('LGPL-3.0')
+groups=('hvml')
 provides=(${pkgname} 'PurC')
 conflicts=(${pkgname}-git)
 #replaces=(${pkgname})
 depends=('glib2' 'bison' 'flex')
 makedepends=('cmake' 'ninja' 'ccache' 'gcc' 'python' 'libxml2' 'ruby' 'curl' 'openssl' 'sqlite' 'pkgconf' 'zlib' 'icu')
-optdepends=('domruler' 'purc-fetcher' 'xguipro')
+optdepends=('domruler: DOM Ruler is a library to maintain a DOM tree, lay out and stylize the DOM elements by using CSS.'
+            'purc-fetcher: The remote data fetcher for PurC.'
+            'purc-midnight-commander: A generic HVML renderer in text mode for development and debugging.'
+            'webkit2gtk-hvml: Web content engine for GTK (HVML)'
+            'xguipro: xGUI (the X Graphics User Interface) Pro is a modern, cross-platform, and advanced HVML renderer which is based on tailored WebKit.')
 backup=()
 options=('!strip')
 #install=${pkgname}.install


### PR DESCRIPTION
1. Add PurC optional dependency packages
- The HVML related package (packaged) has been added as an optional dependent package.
2. package group hvml and hvml-git information
- Install all HVML development packages (packaged versions) by installing `hvml-git`

```bash
yay -S hvml-git
```

- Also install `hvml` to install the latest installation package that has been released by HVML.

```bash
yay -S hvml
```

Note: the package group feature needs to be enabled after `PurC-Midnight-Commander` [1](https://github.com/HVML/PurC-Midnight-Commander/issues/1)is packaged. 