### PR TITLE
fix: specify the execution path of bison or flex on mac

### DIFF
--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -22,6 +22,33 @@ find_package(LibXslt 1.1.7)
 find_package(CURL 7.60.0)
 find_package(OpenSSL 1.1.1)
 find_package(SQLite3 3.10.0)
+
+# On macOS, search Homebrew for keg-only versions of Bison and Flex. Xcode does
+# not provide new enough versions for us to use.
+if (CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+    execute_process(
+        COMMAND brew --prefix bison
+        RESULT_VARIABLE BREW_BISON
+        OUTPUT_VARIABLE BREW_BISON_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (BREW_BISON EQUAL 0 AND EXISTS "${BREW_BISON_PREFIX}")
+        message(STATUS "Found Bison keg installed by Homebrew at ${BREW_BISON_PREFIX}")
+        set(BISON_EXECUTABLE "${BREW_BISON_PREFIX}/bin/bison")
+    endif ()
+
+    execute_process(
+        COMMAND brew --prefix flex
+        RESULT_VARIABLE BREW_FLEX
+        OUTPUT_VARIABLE BREW_FLEX_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (BREW_FLEX EQUAL 0 AND EXISTS "${BREW_FLEX_PREFIX}")
+        message(STATUS "Found Flex keg installed by Homebrew at ${BREW_FLEX_PREFIX}")
+        set(FLEX_EXECUTABLE "${BREW_FLEX_PREFIX}/bin/flex")
+    endif ()
+endif ()
+
 find_package(BISON 3.0 REQUIRED)
 find_package(FLEX 2.6.4 REQUIRED)
 


### PR DESCRIPTION
Mac 系统中自带有 BISON 和 FLEX，但有时候版本比较低，且受系统安全机制保护(可以通过安全模式替换，但比较麻烦)，在编译工具中无法切换用户自行更新的更高版本，例如 cmake 一直使用 `/usr/bin/bison` (v2.3)， 用户自已更新的在 `/usr/local/opt/bison/bin` (v3.x) 且加到 $PATH 或 使用 `export LDFLAGS="-L/usr/local/opt/bison/lib"` 也无法切换 bison 的版本，导致编译失败。

该 pr 可以使用 `brew --prefix` 命令预先查出实际使用的 bison 可执行文件地址，解决一些 Mac 系统中的默认编译问题。

对于不使用 brew 的用户，后续建议增加可以指定 bison 可执行文件地址的 cmake 参数。