### PR TITLE
Update python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE True)
 #------------------------------------------------------------------------------
 include(PurCCommon)
 
-SET_PROJECT_VERSION(0 9 14)
+SET_PROJECT_VERSION(0 9 15)
 
 add_subdirectory(Source)
 

--- a/Source/cmake/PurCCommon.cmake
+++ b/Source/cmake/PurCCommon.cmake
@@ -14,7 +14,7 @@ if (NOT HAS_RUN_PURC_COMMON)
     endif ()
 
     set(Python_ADDITIONAL_VERSIONS 3)
-    find_package(Python2 2.7.0 REQUIRED)
+    find_package(Python3 3.9.0 REQUIRED)
 
     # -----------------------------------------------------------------------------
     # Helper macros and feature defines


### PR DESCRIPTION
使用 python2 在新版本 cmake 3.27.4 中会识别错误，而且 python2 已经停止维护，python 官方的建议也是升级到 python3 。
相关的报错信息，替换成 python3 编译正常。
```bash
❯ makepkg -sf  
==> 正在创建软件包：purc-git 0.9.15.r0.g0ddaf1f31-1 (2023年09月02日 星期六 23时04分03秒)
==> 正在检查运行时依赖关系...
==> 正在检查编译时依赖关系==> 获取源代码...
  -> 正在升级 purc git 仓库...
==> 正在验证 source 文件，使用sha256sums...
    purc ... 已跳过==> 正在释放源码...
  -> 正在建立 purc git 仓库的拷贝...
重置分支 'makepkg'
==> 正在开始 pkgver()...
==> 正在删除现存的 $pkgdir/ 目录...
==> 正在开始 build()...
-- The CMake build type is: None
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Python2 (missing: Python2_EXECUTABLE Interpreter) (Required
  is at least version "2.7.0")

      Reason given by package: 
          Interpreter: Wrong version for the interpreter "/sbin/python"

Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake/Modules/FindPython/Support.cmake:3824 (find_package_handle_standard_args)
  /usr/share/cmake/Modules/FindPython2.cmake:427 (include)
  Source/cmake/PurCCommon.cmake:17 (find_package)
  CMakeLists.txt:139 (include)


-- Configuring incomplete, errors occurred!
==> 错误： 在 build() 中发生一个错误。    正在放弃...
```